### PR TITLE
use cli_util to locate the sdk

### DIFF
--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -7,7 +7,7 @@ library tuneup.common;
 import 'dart:async';
 import 'dart:io';
 
-import 'package:grinder/grinder.dart' as grinder;
+import 'package:cli_util/cli_util.dart' as cli_util;
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart' as yaml;
 
@@ -44,7 +44,7 @@ class Project {
     }
   }
 
-  String get sdkPath => grinder.getSdkDir(cliArgs).path;
+  String get sdkPath => cli_util.getSdkDir(cliArgs).path;
 
   String get packagePath => 'packages';
 

--- a/lib/tuneup.dart
+++ b/lib/tuneup.dart
@@ -11,7 +11,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:grinder/grinder.dart';
+import 'package:path/path.dart'as p;
 
 import 'src/check_command.dart';
 import 'src/clean_command.dart';
@@ -85,7 +85,7 @@ class Tuneup {
     Command command = _commands[options.command.name];
 
     // Verify that we are being run from a project directory.
-    File pubspec = joinFile(directory, ['pubspec.yaml']);
+    File pubspec = new File(p.join(directory.path, 'pubspec.yaml'));
     if (command.name != 'init' && !pubspec.existsSync()) {
       String message =
           'No pubspec.yaml file found. The tuneup command should be run from '

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,11 +12,12 @@ environment:
 dependencies:
   analyzer: '>=0.23.0 <0.24.0'
   args: '>=0.12.0 <0.13.0'
-  grinder: '>=0.6.4 <0.7.0'
+  cli_util: '>=0.0.1 <0.1.0'
   path: '>=1.0.0 <2.0.0'
   yaml: '>=2.0.0 <3.0.0'
 
 dev_dependencies:
+  grinder: '>=0.6.4 <0.7.0'
   unittest: any
 
 # Add the bin/tuneup.dart script to the scripts pub installs.


### PR DESCRIPTION
Switch to using `cli_util` to locate the sdk, and move `grinder` back to a dev_dependency.