### PR TITLE
added a --directory option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.3
+- upgraded the analyzer version to capture a change to analyzing unnamed
+  libraries
+- added a `--directory` flag to support analyzing something besides the current
+  working directory
+
 ## 0.1.2
 - fixed an issue analyzing libraries that were referred to by both self-references
   (package: references) and relative path references

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -46,11 +46,11 @@ class Project {
 
   String get sdkPath => cli_util.getSdkDir(cliArgs).path;
 
-  String get packagePath => 'packages';
+  String get packagePath => p.join(dir.path, 'packages');
 
   Directory get packageDir => new Directory(packagePath);
 
-  File get packagesFile => new File('.packages');
+  File get packagesFile => new File(p.join(dir.path, '.packages'));
 
   yaml.YamlMap get pubspec {
     return yaml.loadYaml(

--- a/lib/tuneup.dart
+++ b/lib/tuneup.dart
@@ -133,7 +133,7 @@ class Tuneup {
     parser.addFlag('version', negatable: false,
         help: 'Display the application version.');
     parser.addOption('dart-sdk', hide: true, help: 'the path to the sdk');
-    parser.addOption('directory', help: 'the project directory to analyze');
+    parser.addOption('directory', help: 'The project directory to analyze.');
 
     // init
     ArgParser commandParser = parser.addCommand('init');

--- a/lib/tuneup.dart
+++ b/lib/tuneup.dart
@@ -23,7 +23,7 @@ import 'src/trim_command.dart';
 export 'src/common.dart' show CliLogger;
 
 // This version must be updated in tandem with the pubspec version.
-const String APP_VERSION = '0.1.2';
+const String APP_VERSION = '0.1.3';
 const String APP_NAME = 'tuneup';
 
 class Tuneup {
@@ -80,6 +80,16 @@ class Tuneup {
       return new Future.value();
     }
 
+    if (options['directory'] != null) {
+      Directory dir = new Directory(options['directory']);
+      if (!dir.existsSync()) {
+        var message = 'Directory specified does not exist "${directory.path}".';
+        _out('Error: ${message}');
+        return new Future.error(new ArgError(message));
+      }
+      directory = dir;
+    }
+
     Project project = new Project(directory, logger);
     File pubspec = new File(p.join(directory.path, 'pubspec.yaml'));
 
@@ -119,12 +129,11 @@ class Tuneup {
   ArgParser _createArgParser() {
     ArgParser parser = new ArgParser();
 
-    parser.addFlag('help', abbr: 'h', negatable: false,
-        help: 'Help!');
+    parser.addFlag('help', abbr: 'h', negatable: false, help: 'Help!');
     parser.addFlag('version', negatable: false,
         help: 'Display the application version.');
-    parser.addOption('dart-sdk', hide: true,
-        help: 'the path to the sdk');
+    parser.addOption('dart-sdk', hide: true, help: 'the path to the sdk');
+    parser.addOption('directory', help: 'the project directory to analyze');
 
     // init
     ArgParser commandParser = parser.addCommand('init');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: tuneup
 description: A command-line tool to manipulate and inspect your Dart projects.
 
 # This version must be updated in tandem with the lib/tuneup.dart version.
-version: 0.1.2
+version: 0.1.3
 author: Devon Carew <devoncarew@google.com>
 homepage: https://github.com/google/tuneup.dart
 
@@ -10,7 +10,7 @@ environment:
   sdk: '>=1.8.0 <2.0.0'
 
 dependencies:
-  analyzer: ^0.26.0
+  analyzer: ^0.26.1+1
   args: '>=0.12.0 <0.14.0'
   cli_util: '>=0.0.1 <0.1.0'
   path: '>=1.0.0 <2.0.0'

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -33,6 +33,7 @@ void defineTests() {
       return tuneup.processArgs(['init'], directory: foo).then((_) {
         expect(new File('foo/bin/helloworld.dart').existsSync(), true);
       }).then((_) {
+        _setupPub();
         return tuneup.processArgs(['check'], directory: foo);
       }).then((_) {
         expect(logger.out, contains('No issues found; analyzed 1 source file in'));
@@ -119,6 +120,7 @@ void defineTests() {
       return tuneup.processArgs(['init'], directory: foo).then((_) {
         expect(new File('foo/bin/helloworld.dart').existsSync(), true);
       }).then((_) {
+        _setupPub();
         return tuneup.processArgs(['check'], directory: foo);
       }).then((_) {
         expect(logger.out, contains('No issues found; analyzed 1 source file in'));
@@ -133,6 +135,7 @@ void defineTests() {
         expect(f.existsSync(), true);
         f.writeAsStringSync(_errorText);
       }).then((_) {
+        _setupPub();
         return tuneup.processArgs(['check'], directory: foo);
       }).then((_) {
         fail('expected analysis errors');
@@ -156,6 +159,12 @@ void defineTests() {
       });
     });
   });
+}
+
+void _setupPub() {
+  File pubspec = new File('foo/pubspec.yaml');
+  pubspec.writeAsStringSync('name: foo\n');
+  Process.runSync('pub', ['get'], workingDirectory: 'foo');
 }
 
 class _Logger implements CliLogger {


### PR DESCRIPTION
- upgraded the analyzer version to capture a change to analyzing unnamed libraries
- added a `--directory` flag to support analyzing something besides the current working directory