### PR TITLE
use the analysis server to perform analysis

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -2,3 +2,12 @@ analyzer:
   strong-mode: true
   exclude:
     - test/data/*
+linter:
+  rules:
+    # - annotate_overrides
+    - avoid_init_to_null
+    - directives_ordering
+    - no_adjacent_strings_in_list
+    - package_api_docs
+    # - slash_for_doc_comments
+    # - unnecessary_brace_in_string_interps

--- a/bin/tuneup.dart
+++ b/bin/tuneup.dart
@@ -2,8 +2,6 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library tuneup.main;
-
 import 'dart:io';
 
 import 'package:tuneup/src/common.dart';

--- a/lib/src/analysis_server_lib.dart
+++ b/lib/src/analysis_server_lib.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // This is a generated file.
 
 /// A library to access the analysis server API.

--- a/lib/src/ansi.dart
+++ b/lib/src/ansi.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+bool terminalSupportsAnsi() {
+  return !Platform.isWindows && stdioType(stdout) == StdioType.TERMINAL;
+}
+
+class Ansi {
+  final bool useAnsi;
+
+  String get cyan => _code('\u001b[36m');
+  String get green => _code('\u001b[32m');
+  String get magenta => _code('\u001b[35m');
+  String get red => _code('\u001b[31m');
+  String get yellow => _code('\u001b[33m');
+  String get blue => _code('\u001b[34m');
+  String get gray => _code('\u001b[1;30m');
+  String get noColor => _code('\u001b[39m');
+
+  String get none => _code('\u001b[0m');
+
+  String get bold => _code('\u001b[1m');
+
+  String get backspace => '\b';
+
+  Ansi(this.useAnsi);
+
+  String get bullet => Platform.isWindows ? '-' : '•';
+
+  String _code(String ansiCode) => useAnsi ? ansiCode : '';
+}

--- a/lib/src/clean_command.dart
+++ b/lib/src/clean_command.dart
@@ -2,8 +2,6 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library tuneup.clean_command;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -10,7 +10,7 @@ import 'package:analyzer/file_system/file_system.dart' as analysisFile
 import 'package:analyzer/file_system/file_system.dart' show ResourceProvider;
 import 'package:analyzer/file_system/physical_file_system.dart';
 import 'package:analyzer/source/analysis_options_provider.dart';
-import 'package:analyzer/src/generated/engine.dart';
+import 'package:analyzer/src/generated/engine.dart' hide Logger;
 import 'package:intl/intl.dart';
 import 'package:path/path.dart' as path;
 import 'package:quiver/pattern.dart' show Glob;
@@ -42,7 +42,7 @@ class Project {
   ];
 
   final Directory dir;
-  final StandardLogger logger;
+  final Logger logger;
   final Ansi ansi;
 
   List<Glob> _excludes = [];

--- a/lib/src/init_command.dart
+++ b/lib/src/init_command.dart
@@ -2,8 +2,6 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library tuneup.init_command;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -1,0 +1,187 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io' as io;
+
+import 'ansi.dart';
+
+abstract class Logger {
+  void stderr(String message);
+  void stdout(String message);
+  void trace(String message);
+
+  Progress progress(String message);
+  void progressFinished(Progress progress);
+
+  void flush();
+}
+
+abstract class Progress {
+  final String message;
+
+  Progress(this.message);
+
+  void finish();
+  void cancel();
+}
+
+class StandardLogger implements Logger {
+  final Ansi ansi;
+
+  StandardLogger(this.ansi);
+
+  Progress _currentProgress;
+
+  void stderr(String message) {
+    io.stderr.writeln(message);
+    _currentProgress?.cancel();
+    _currentProgress = null;
+  }
+
+  void stdout(String message) {
+    print(message);
+    _currentProgress?.cancel();
+    _currentProgress = null;
+  }
+
+  void trace(String message) {}
+
+  Progress progress(String message) {
+    _currentProgress?.cancel();
+    _currentProgress = null;
+
+    Progress progress = ansi.useAnsi
+        ? new AnsiProgress(this, ansi, message)
+        : new SimpleProgress(this, message, printWhenFinished: false);
+    _currentProgress = progress;
+    return progress;
+  }
+
+  void progressFinished(Progress progress) {
+    if (_currentProgress == progress) {
+      _currentProgress = null;
+    }
+  }
+
+  void flush() {}
+}
+
+class SimpleProgress extends Progress {
+  final Logger logger;
+  final bool printWhenFinished;
+
+  SimpleProgress(this.logger, String message, {this.printWhenFinished: true})
+      : super(message) {
+    logger.stdout('$message...');
+  }
+
+  @override
+  void cancel() {
+    logger.progressFinished(this);
+  }
+
+  @override
+  void finish() {
+    if (printWhenFinished) logger.stdout('$message finished.');
+    logger.progressFinished(this);
+  }
+}
+
+class AnsiProgress extends Progress {
+  static const List<String> kAnimationItems = const ['/', '-', '\\', '|'];
+
+  final Logger logger;
+  final Ansi ansi;
+
+  int _index = 0;
+  Timer _timer;
+
+  AnsiProgress(this.logger, this.ansi, String message) : super(message) {
+    io.stdout.write('${message}...  '.padRight(40));
+
+    _timer = new Timer.periodic(new Duration(milliseconds: 80), (t) {
+      _index++;
+      _updateDisplay();
+    });
+
+    _updateDisplay();
+  }
+
+  @override
+  void cancel() {
+    if (_timer.isActive) {
+      _timer.cancel();
+      _updateDisplay(cancelled: true);
+      logger.progressFinished(this);
+    }
+  }
+
+  @override
+  void finish() {
+    if (_timer.isActive) {
+      _timer.cancel();
+      _updateDisplay(isFinal: true);
+      logger.progressFinished(this);
+    }
+  }
+
+  void _updateDisplay({bool isFinal: false, bool cancelled: false}) {
+    String char = kAnimationItems[_index % kAnimationItems.length];
+    if (isFinal || cancelled) {
+      char = ' ';
+    }
+    io.stdout.write('${ansi.backspace}${char}');
+    if (isFinal || cancelled) {
+      io.stdout.writeln();
+    }
+  }
+}
+
+class VerboseLogger implements Logger {
+  final Ansi ansi;
+  Stopwatch _timer;
+
+  String _previousErr;
+  String _previousMsg;
+
+  VerboseLogger(this.ansi) {
+    _timer = new Stopwatch()..start();
+  }
+
+  void stderr(String message) {
+    flush();
+    _previousErr = '${ansi.red}$message${ansi.none}';
+  }
+
+  void stdout(String message) {
+    flush();
+    _previousMsg = message;
+  }
+
+  void trace(String message) {
+    flush();
+    _previousMsg = '${ansi.gray}$message${ansi.none}';
+  }
+
+  Progress progress(String message) => new SimpleProgress(this, message);
+
+  void progressFinished(Progress progress) {}
+
+  void flush() {
+    if (_previousErr != null) {
+      io.stderr.writeln('${_createTag()} $_previousErr');
+      _previousErr = null;
+    } else if (_previousMsg != null) {
+      io.stdout.writeln('${_createTag()} $_previousMsg');
+      _previousMsg = null;
+    }
+  }
+
+  String _createTag() {
+    int millis = _timer.elapsedMilliseconds;
+    _timer.reset();
+    return '[${millis.toString().padLeft(4)} ms]';
+  }
+}

--- a/lib/src/stats_command.dart
+++ b/lib/src/stats_command.dart
@@ -2,8 +2,6 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library tuneup.info_command;
-
 import 'dart:async';
 import 'dart:io';
 
@@ -42,8 +40,8 @@ class StatsCommand extends Command {
 
     // "Found 288 Dart files and 44,863 lines of code."
     // TODO: print a breakdown by type
-    project.print('Found ${format(all.files)} source files and '
-        '${format(all.lines)} lines of code.');
+    project.print('Found ${formatNumber(all.files)} source files and '
+        '${formatNumber(all.lines)} lines of code.');
 
     return new Future.value();
   }

--- a/lib/src/trim_command.dart
+++ b/lib/src/trim_command.dart
@@ -2,8 +2,6 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library tuneup.trim_command;
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/lib/tuneup.dart
+++ b/lib/tuneup.dart
@@ -23,8 +23,6 @@ import 'src/logger.dart';
 import 'src/stats_command.dart';
 import 'src/trim_command.dart';
 
-export 'src/logger.dart' show StandardLogger;
-
 // This version must be updated in tandem with the pubspec version.
 const String appVersion = '0.3.0';
 const String appName = 'tuneup';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: tuneup
 description: A command-line tool to manipulate and inspect your Dart projects.
 
 # This version must be updated in tandem with the lib/tuneup.dart version.
-version: 0.2.6
+version: 0.3.0
 author: Devon Carew <devoncarew@google.com>
 homepage: https://github.com/google/tuneup.dart
 
@@ -10,11 +10,11 @@ environment:
   sdk: '>=1.8.0 <2.0.0'
 
 dependencies:
-  analyzer: 0.30.0-alpha.1
+  analyzer: '>=0.29.0 <0.31.0'
   args: '>=0.12.0 <0.14.0'
+  intl: ^0.15.0
   logging: ^0.11.0
   path: '>=1.0.0 <2.0.0'
-  package_config: ^1.0.0
   quiver: ^0.24.0
   yaml: '>=2.0.0 <3.0.0'
 

--- a/test/all.dart
+++ b/test/all.dart
@@ -2,8 +2,6 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library tuneup.all_tests;
-
 import 'analysis_lib_test.dart' as analysis_lib_test;
 import 'common_test.dart' as common_test;
 import 'integration_test.dart' as integration_test;

--- a/test/common_test.dart
+++ b/test/common_test.dart
@@ -16,13 +16,13 @@ void defineTests() {
     });
 
     test('format', () {
-      expect(format(0), '0');
-      expect(format(10), '10');
-      expect(format(100), '100');
-      expect(format(1000), '1,000');
-      expect(format(10000), '10,000');
-      expect(format(100000), '100,000');
-      expect(format(1000000), '1,000,000');
+      expect(formatNumber(0), '0');
+      expect(formatNumber(10), '10');
+      expect(formatNumber(100), '100');
+      expect(formatNumber(1000), '1,000');
+      expect(formatNumber(10000), '10,000');
+      expect(formatNumber(100000), '100,000');
+      expect(formatNumber(1000000), '1,000,000');
     });
   });
 }

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:tuneup/src/common.dart';
+import 'package:tuneup/src/logger.dart';
 import 'package:tuneup/tuneup.dart';
 import 'package:unittest/unittest.dart';
 
@@ -28,7 +29,7 @@ void defineTests() {
     });
 
     test('no args', () {
-      Tuneup tuneup = new Tuneup(logger);
+      Tuneup tuneup = new Tuneup(logger: logger);
       return tuneup.processArgs(['init'], directory: foo).then((_) {
         expect(new File('foo/bin/helloworld.dart').existsSync(), true);
       }).then((_) {
@@ -42,7 +43,7 @@ void defineTests() {
     });
 
     test('bad command', () {
-      Tuneup tuneup = new Tuneup(logger);
+      Tuneup tuneup = new Tuneup(logger: logger);
       return tuneup.processArgs(['foo_command'], directory: foo).then((_) {
         fail('expected exception');
       }).catchError((e) {
@@ -51,7 +52,7 @@ void defineTests() {
     });
 
     test('bad arg', () {
-      Tuneup tuneup = new Tuneup(logger);
+      Tuneup tuneup = new Tuneup(logger: logger);
       return tuneup.processArgs(['--foo', 'bar'], directory: foo).then((_) {
         fail('should have thrown');
       }).catchError((e) {
@@ -61,7 +62,7 @@ void defineTests() {
     });
 
     test('--help', () {
-      Tuneup tuneup = new Tuneup(logger);
+      Tuneup tuneup = new Tuneup(logger: logger);
       return tuneup.processArgs(['--help'], directory: foo).then((_) {
         expect(logger.out,
             contains('A tool to improve visibility into your Dart projects.'));
@@ -71,7 +72,7 @@ void defineTests() {
     });
 
     test('--version', () {
-      Tuneup tuneup = new Tuneup(logger);
+      Tuneup tuneup = new Tuneup(logger: logger);
       return tuneup.processArgs(['--version'], directory: foo).then((_) {
         expect(logger.out, contains('tuneup version '));
         expect(logger.err, isEmpty);
@@ -79,14 +80,14 @@ void defineTests() {
     });
 
     test('init', () {
-      Tuneup tuneup = new Tuneup(logger);
+      Tuneup tuneup = new Tuneup(logger: logger);
       return tuneup.processArgs(['init'], directory: foo).then((_) {
         expect(new File('foo/bin/helloworld.dart').existsSync(), true);
       });
     });
 
     test('stats', () {
-      Tuneup tuneup = new Tuneup(logger);
+      Tuneup tuneup = new Tuneup(logger: logger);
       return tuneup.processArgs(['init'], directory: foo).then((_) {
         expect(new File('foo/bin/helloworld.dart').existsSync(), true);
         File other = new File('foo/web/index.html');
@@ -101,7 +102,7 @@ void defineTests() {
     });
 
     test('trim', () {
-      Tuneup tuneup = new Tuneup(logger);
+      Tuneup tuneup = new Tuneup(logger: logger);
       File hello = new File('foo/bin/helloworld.dart');
       File other = new File('foo/web/index.html');
 
@@ -118,7 +119,7 @@ void defineTests() {
     });
 
     test('check', () {
-      Tuneup tuneup = new Tuneup(logger);
+      Tuneup tuneup = new Tuneup(logger: logger);
       return tuneup.processArgs(['init'], directory: foo).then((_) {
         expect(new File('foo/bin/helloworld.dart').existsSync(), true);
       }).then((_) {
@@ -132,7 +133,7 @@ void defineTests() {
     });
 
     test('check with errors', () {
-      Tuneup tuneup = new Tuneup(logger);
+      Tuneup tuneup = new Tuneup(logger: logger);
       return tuneup.processArgs(['init'], directory: foo).then((_) {
         File f = new File('foo/bin/helloworld.dart');
         expect(f.existsSync(), true);
@@ -151,7 +152,7 @@ void defineTests() {
     });
 
     test('clean', () {
-      Tuneup tuneup = new Tuneup(logger);
+      Tuneup tuneup = new Tuneup(logger: logger);
       return tuneup.processArgs(['init'], directory: foo).then((_) {
         expect(new File('foo/bin/helloworld.dart').existsSync(), true);
       }).then((_) {
@@ -171,15 +172,23 @@ void _setupPub() {
   Process.runSync('pub', ['get'], workingDirectory: 'foo');
 }
 
-class _Logger implements CliLogger {
+class _Logger implements Logger {
   StringBuffer _out = new StringBuffer();
   StringBuffer _err = new StringBuffer();
+  StringBuffer _trc = new StringBuffer();
 
   void stdout(String message) => _out.writeln(message);
   void stderr(String message) => _err.writeln(message);
+  void trace(String message) => _trc.writeln(message);
+
+  Progress progress(String message) => new SimpleProgress(this, message);
+  void progressFinished(Progress progress) { }
+
+  void flush() { }
 
   String get out => _out.toString();
   String get err => _err.toString();
+  String get trc => _trc.toString();
 }
 
 String _errorText = '''

--- a/tool/analysis/analysis_tester.dart
+++ b/tool/analysis/analysis_tester.dart
@@ -1,4 +1,6 @@
-library analysis_tester;
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 
 import 'dart:async';
 import 'dart:convert';

--- a/tool/analysis/generate_analysis.dart
+++ b/tool/analysis/generate_analysis.dart
@@ -1,4 +1,6 @@
-library generate_analysis_lib;
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 
 import 'dart:collection' show LinkedHashMap;
 import 'dart:io';
@@ -772,6 +774,10 @@ class PrimitiveType extends Type {
 }
 
 final String _headerCode = r'''
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // This is a generated file.
 
 /// A library to access the analysis server API.

--- a/tool/analysis/src_gen.dart
+++ b/tool/analysis/src_gen.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 /// A library to generate Dart source code.
 library src_gen;
 

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -8,7 +8,7 @@
 set -e
 
 # Verify that the libraries are error free.
-dart -c bin/tuneup.dart check
+dart -c bin/tuneup.dart check --no-color
 
 # Run the tests.
 dart -c test/all.dart


### PR DESCRIPTION
A fairly big retofit:

- use the analysis server to perform analysis; use the analysis server's wire protocol to perform analysis for the `check` command. This gives us a substantial speed benefit, and means we're not reliant on using the latest version of the analyzer library. 
- rev to `0.3.0`