### PR TITLE
Added "ignore-todos" flag to "tuneup check" command.

### DIFF
--- a/lib/commands/check.dart
+++ b/lib/commands/check.dart
@@ -17,6 +17,8 @@ class CheckCommand extends TuneupCommand {
       : super(tuneup, 'check', 'analyze all the source code in the project') {
     argParser.addFlag('ignore-infos',
         negatable: false, help: 'Ignore any info level issues.');
+    argParser.addFlag('ignore-todos',
+        help: 'Ignores "TODO" comments.', defaultsTo: true);
     argParser.addFlag('preview-dart-2',
         help: 'Run the analysis server opt-ed into Dart 2.');
     argParser.addFlag('use-cfe',
@@ -142,8 +144,10 @@ class CheckCommand extends TuneupCommand {
       return a;
     });
 
-    // Don't show todos.
-    errors.removeWhere((e) => e.code == 'todo');
+    if (argResults['ignore-todos']) {
+      // Don't show todos.
+      errors.removeWhere((e) => e.code == 'todo');
+    }
 
     // Optionally filter out infos.
     bool ignoreInfos = argResults == null ? false : argResults['ignore-infos'];

--- a/lib/commands/check.dart
+++ b/lib/commands/check.dart
@@ -17,8 +17,10 @@ class CheckCommand extends TuneupCommand {
       : super(tuneup, 'check', 'analyze all the source code in the project') {
     argParser.addFlag('ignore-infos',
         negatable: false, help: 'Ignore any info level issues.');
-    argParser.addFlag('ignore-todos',
-        help: 'Ignores "TODO" comments.', defaultsTo: true);
+    argParser.addFlag('fail-on-todos',
+        help: 'Fail if any TODOs are found.',
+        negatable: false,
+        defaultsTo: false);
     argParser.addFlag('preview-dart-2',
         help: 'Run the analysis server opt-ed into Dart 2.');
     argParser.addFlag('use-cfe',
@@ -144,7 +146,7 @@ class CheckCommand extends TuneupCommand {
       return a;
     });
 
-    if (argResults['ignore-todos']) {
+    if (!argResults['fail-on-todos']) {
       // Don't show todos.
       errors.removeWhere((e) => e.code == 'todo');
     }


### PR DESCRIPTION
While google internally allows/encourages the use of "TODOs" there may be other repos (such as ours) where TODOs are discouraged in favors of e.g. issues.  

Currently there is no way to include TODOs in tuneup. This pull request adds a `ignore-todos` flag which when negated (`tuneup check --no-ignore-todos`) will flag TODOs instead of ignoring them.  
The flag defaults to true (not checking TODOs).